### PR TITLE
Fix a bug that can't use use-simple-atom in react v16.x environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,25 @@
   <a href="https://github.com/kqito/use-simple-atom/blob/main/LICENSE"><img src="https://img.shields.io/github/license/kqito/use-simple-atom" alt="License"></a>
 </p>
 
+## Table of Contents
+
+- [Features](#features)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Examples](#examples)
+- [API](#api)
+
 ## Features
-- A simple atom library
-- Lightweight ( less than 5kB size )
-- No dependencies
+- Lightweight ( less than 6kB size )
+- Simple interface
+- Code splitting of state
 - Support for SSR
-- Prevents the unnecessary renders
 
 ## Installation
-You can install the package from npm.
+We can install the package from npm.
 
 ```
-npm install use-simple-atom
+npm insttll use-simple-atom
 ```
 
 or
@@ -43,15 +50,15 @@ export const counterAtom = createAtom('counter', {
 });
 
 export const Counter = () => {
-  const [{ count }, setState] = useAtom(counterAtom);
+  const [{ count }, setCountState] = useAtom(counterAtom);
 
   return (
     <div>
       <p>Counter: {count}</p>
-      <button onClick={() => setState(({ count }) => { count: count + 1 })}>
+      <button onClick={() => setCountState(({ count }) => { count: count + 1 })}>
         Increment
       </button>
-      <button onClick={() => setState(({ count }) => { count: count - 1 })}>
+      <button onClick={() => setCountState(({ count }) => { count: count - 1 })}>
         Decrement
       </button>
     </div>
@@ -65,165 +72,13 @@ const App = () => (
 )
 ```
 
-## API
-### `useAtom` hooks
-
-```tsx
-const [state, setState] = useAtom(atom, { selector, equalFn });
-```
-
-`useAtom` is a hooks to get the state of an atom and the function to update it.
-
-### Arguments
-- `atom` (type: `Atom<T>`)
-  - Atom created by `createAtom` API.
-
-- `selector` (type: `(state: T) => S | undefined`)
-   - Function option that allows you to extract only the state you need from the atom.
-
-- `equalFn` (type: `(a: any, b: any) => boolean`)
-  - A function that compares the current value of store with the value of store when it changes.
-  - If the return value is true, re-rendering will occur.
-
-
-### Returns
-- `state` (type: `T`)
-  - State of the atom specified in the argument.
-
-- `setState` (type: `(newState: ((state: T) => T) | T) => void`)
-  - Function to update the state.
-
----
-
-### `useAtomState` hooks
-
-```tsx
-const state = useAtomState(atom, useAtomStateOptions);
-```
-
-`useAtomState` is a hooks to get the state of an atom.
-
-### Arguments
-- `atom` (type: `Atom<T>`)
-  - Atom created by `createAtom` API.
-
-- `useAtomStateOptions` (type: `UseAtomStateOptions<T>`)
-  - same as `useAtomOptions`.
-
-### Returns
-- `state` (type: `T`)
-  - State of the atom specified in the argument.
-
----
-
-### `useAtomSetState` hooks
-
-```tsx
-const setState = useAtomState(atom);
-```
-
-`useAtomState` is a hooks to get the state of an atom.
-
-### Arguments
-- `atom` (type: `Atom<T>`)
-  - Atom created by `createAtom` API.
-
-### Returns
-- `setState` (type: `(newState: ((state: T) => T) | T) => void`)
-  - Function to update the state.
-
----
-
-### `createAtom` function
-
-```tsx
-const atom = createAtom(key, value, { equalFn });
-```
-
-`createAtom` is a function to create atom.
-
-### Arguments
-- `key` (type: `string`)
-  - The atom key must be unique.
-
-- `value` (type: `T`)
-  - Initial value of atom.
-
-- `equalFn` (type: `(a: any, b: any) => boolean`)
-  - If no equalFn option such as useAtom hooks is specified, this value will be applied.
-  - Default is `Object.is`.
-  - A function that compares the current value of store with the value of store when it changes.
-  - If the return value is true, re-rendering will occur.
-
-### `createPreloadAtom` function
-
-```tsx
-const atom = createPreloadAtom(key, value, { equalFn });
-```
-
-`createPreloadAtom` is a function to create preload atom.
-
-`Preload atom` can be used when you want to use a SSG value as the initial value.
-
-### Arguments
-same as `createAtom`
-
-### Returns
-- `atom` (type: `Atom<T>`)
-  - Atom available for useAtom hooks, etc.
-
----
-
-### `AtomStoreProvider` component
-
-```tsx
- <AtomStoreProvider atomStore={atomStore} preloadValues={preloadValues}>
-  { children here... }
- </AtomStoreProvider>
-```
-
-`AtomStoreProvider` is a component for managing atom.
-
-** In order to use the useAtom hooks etc, you need to set the `AtomStoreProvider` on the parent or higher element. **
-
-### Props
-- `atomStore` (type: `AtomStore | undefined`)
-  - props to set the store created by the `createAtomStore` function to Provider
-
-- `preloadValues` (type: `Record<string, unknown> | undefined`)
-  - props used to store key and value as a preload atom.
-  - This is useful for inheriting SSR values.
-
----
-
-### `createAtomStore` function
-
-```tsx
-const atomStore = createAtomStore()
-```
-
-`createAtomStore` is a function that creates a store. It is mainly used for SSR.
-
-### AtomStore
-- `AtomStore.getAtoms` (type:  `Record<string, unknown>`)
-  - Function to get the atoms stored in the store.
-
----
-
-### `useAtomStore` hooks
-
-```tsx
-const atomStore = useAtomStore()
-```
-
-`useAtomStore` is a hooks that get store in `AtomStoreProvider`.
-
 ## Examples
 The following are some example of how to use `use-simple-atom`.
 
 Note that the `AtomStoreProvider` must be specified as the parent or higher element.
 
 ### Basic
+We can use the state and the function to update it from atom as follows
 
 ```tsx
 import { useAtom, createAtom } from 'use-simple-atom'
@@ -232,16 +87,25 @@ export const counterAtom = createAtom('counter', {
   count: 0
 });
 
+export const userAtom = createAtom('userInfomation', {
+  age: 22,
+  name: 'kqito'
+});
+
 export const Counter = () => {
-  const [{ count }, setState] = useAtom(counterAtom);
+  const [{ count }, setCountState] = useAtom(counterAtom);
+  // get only state without setState function
+  const userState = useAtomState(userAtom);
+  // get only setState function without state
+  const setUserState = useAtomSetState(userAtom);
 
   return (
     <div>
       <p>Counter: {count}</p>
-        <button onClick={() => setState({ count: count + 1 })}>
+        <button onClick={() => setCountState({ count: count + 1 })}>
           Increment
         </button>
-        <button onClick={() => setState({ count: count - 1 })}>
+        <button onClick={() => setCountState({ count: count - 1 })}>
           Decrement
         </button>
     </div>
@@ -249,58 +113,33 @@ export const Counter = () => {
 };
 ```
 
-### Read only state of atom
+### Selector
+
+If specify `selector`, we can extract only the necessary values from the atom
 
 ```tsx
 import { useAtomState, createAtom } from 'use-simple-atom'
 
-export const counterAtom = createAtom('counter', {
-  count: 0
-});
-
-export const userAtom = createAtom('user', {
-  age: 22
+export const userAtom = createAtom('userInfomation', {
+  age: 22,
+  name: 'kqito'
 });
 
 export const Counter = () => {
-  const { count } = useAtomState(counterAtom);
-  const age = useAtomState(userAtom, { selector: ({ age }) => age });
+  const age = useAtomState(counterAtom, { selector: ({ age }) => age });
+  // The following code is same as the above
+  // const [ age ] = useState(counterAtom, { selector: ({ age }) => age });
 
   return (
     <div>
-      <p>Counter: {count}</p>
       <p>Age: {age}</p>
     </div>
   );
 };
 ```
 
-### Get only setState of atom
-
-```tsx
-import { useAtomSetState, createAtom } from 'use-simple-atom'
-
-export const counterAtom = createAtom('counter', {
-  count: 0
-});
-
-export const Counter = () => {
-  const setState = useAtomSetState(counterAtom);
-
-  return (
-    <div>
-      <button onClick={() => setState(({ count }) => { count: count + 1 })}>
-        Increment
-      </button>
-      <button onClick={() => setState(({ count }) => { count: count - 1 })}>
-        Decrement
-      </button>
-    </div>
-  );
-};
-```
-
 ### With deep equal
+If you want to change the equal function, you can specify the equalFn option. (default: `Object.is`)
 
 ```tsx
 import { useAtomState, createAtom } from 'use-simple-atom'
@@ -316,7 +155,7 @@ export const counterAtom = createAtom('counter',
 );
 
 export const Counter = () => {
-  // web can speicfy equalFn
+  // we can speicfy equalFn
   const countState = useAtomState(counterAtom, { equalFn: deepEqual });
 
   return (
@@ -333,18 +172,13 @@ export const Counter = () => {
 Allow _app to pass initial values to the store by doing the following.
 
 ```tsx
-import { useRef } from 'react';
-import { StoreProvider, createStore } from 'use-simple-atom';
+import { StoreProvider } from 'use-simple-atom';
 
 function MyApp({ Component, pageProps }) {
   const { preloadValues } = pageProps;
 
-  const storeRef = useRef(
-    createStore()
-  );
-
   return (
-    <StoreProvider store={storeRef.current} preloadValues={preloadValues}>
+    <StoreProvider preloadValues={preloadValues}>
       <Component {...pageProps} />
     </StoreProvider>
   );
@@ -384,6 +218,164 @@ export const getStaticProps: GetStaticProps = () => {
   };
 };
 ```
+
+## API
+### `useAtom` hooks
+
+```tsx
+const [state, setState] = useAtom(atom, { selector, equalFn });
+```
+
+`useAtom` is a hooks to get the state of an atom and the function to update it.
+
+#### Arguments
+- `atom` (type: `Atom<T>`)
+  - Atom created by `createAtom` API.
+
+- `selector` (type: `(state: T) => S | undefined`)
+   - Function option that allows you to extract only the state you need from the atom.
+
+- `equalFn` (type: `(a: any, b: any) => boolean`)
+  - A function that compares the current value of store with the value of store when it changes.
+  - If `equalFn` is not specified, the `equalFn` specified in atom will be applied.
+  - If the return value is true, re-rendering will occur.
+
+
+#### Returns
+- `state` (type: `T`)
+  - State of the atom specified in the argument.
+
+- `setState` (type: `(newState: ((state: T) => T) | T) => void`)
+  - Function to update the state.
+
+---
+
+### `useAtomState` hooks
+
+```tsx
+const state = useAtomState(atom, useAtomStateOptions);
+```
+
+`useAtomState` is a hooks to get the state of an atom.
+
+#### Arguments
+- `atom` (type: `Atom<T>`)
+  - Atom created by `createAtom` API.
+
+- `useAtomStateOptions` (type: `UseAtomStateOptions<T>`)
+  - same as `useAtomOptions`.
+
+#### Returns
+- `state` (type: `T`)
+  - State of the atom specified in the argument.
+
+---
+
+### `useAtomSetState` hooks
+
+```tsx
+const setState = useAtomState(atom);
+```
+
+`useAtomState` is a hooks to get the state of an atom.
+
+#### Arguments
+- `atom` (type: `Atom<T>`)
+  - Atom created by `createAtom` API.
+
+#### Returns
+- `setState` (type: `(newState: ((state: T) => T) | T) => void`)
+  - Function to update the state.
+
+---
+
+### `createAtom` function
+
+```tsx
+const atom = createAtom(key, value, { equalFn });
+```
+
+`createAtom` is a function to create atom.
+
+#### Arguments
+- `key` (type: `string`)
+  - The atom key must be unique.
+
+- `value` (type: `T`)
+  - Initial value of atom.
+
+- `equalFn` (type: `(a: any, b: any) => boolean`)
+  - If no equalFn option such as useAtom hooks is specified, this value will be applied.
+  - Default is `Object.is`.
+  - A function that compares the current value of store with the value of store when it changes.
+  - If the return value is true, re-rendering will occur.
+
+---
+
+### `createPreloadAtom` function
+
+```tsx
+const atom = createPreloadAtom(key, value, { equalFn });
+```
+
+`createPreloadAtom` is a function to create preload atom.
+
+`Preload atom` can be used when you want to use a SSG value as the initial value.
+
+#### Arguments
+same as `createAtom`
+
+#### Returns
+- `atom` (type: `Atom<T>`)
+  - Atom available for useAtom hooks, etc.
+
+---
+
+### `AtomStoreProvider` component
+
+```tsx
+ <AtomStoreProvider atomStore={atomStore} preloadValues={preloadValues}>
+  { children here... }
+ </AtomStoreProvider>
+```
+
+`AtomStoreProvider` is a component for managing atom.
+
+**In order to use the useAtom hooks etc, you need to set the `AtomStoreProvider` on the parent or higher element.**
+
+#### Props
+- `atomStore` (type: `AtomStore | undefined`)
+  - props to set the store created by the `createAtomStore` function to Provider
+
+- `preloadValues` (type: `Record<string, unknown> | undefined`)
+  - props used to store key and value as a preload atom.
+  - This is useful for inheriting SSR values.
+
+---
+
+### `createAtomStore` function
+
+```tsx
+const atomStore = createAtomStore()
+```
+
+`createAtomStore` is a function that creates a store. It is mainly used for SSR.
+
+---
+
+### AtomStore
+- `AtomStore.getAtoms` (type:  `Record<string, unknown>`)
+  - Function to get the atoms stored in the store.
+
+---
+
+### `useAtomStore` hooks
+
+```tsx
+const atomStore = useAtomStore()
+```
+
+`useAtomStore` is a hooks that get store in `AtomStoreProvider`.
 
 ## License
 [MIT © kqito](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0"
+    "react": ">=16.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-simple-atom",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A simple atom-based state management for react",
   "keywords": [
     "react",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,12 +14,7 @@ const babelConfig = {
 const distDir = 'dist';
 const baseConfig = {
   input: 'src/index.ts',
-  external: [
-    'react',
-    'react-dom',
-    'react/jsx-runtime',
-    ...Object.keys(pkg.peerDependencies),
-  ],
+  external: ['react', 'react-dom', ...Object.keys(pkg.peerDependencies)],
 };
 
 const dtsConfig = {

--- a/src/core/atomStore/AtomStoreProvider.ts
+++ b/src/core/atomStore/AtomStoreProvider.ts
@@ -1,4 +1,4 @@
-import { FC, useMemo, useRef } from 'react';
+import { createElement, FC, useMemo, useRef } from 'react';
 import { createPreloadAtom } from '../atom/atom';
 import { createAtomStore, IAtomStore, AtomStoreContext } from './atomStore';
 
@@ -24,9 +24,11 @@ export const AtomStoreProvider: FC<AtomStoreProviderProps> = ({
     }
   }, [preloadValues]);
 
-  return (
-    <AtomStoreContext.Provider value={storeRef.current}>
-      {children}
-    </AtomStoreContext.Provider>
+  return createElement(
+    AtomStoreContext.Provider,
+    {
+      value: storeRef.current,
+    },
+    children
   );
 };


### PR DESCRIPTION
## Overview
- fix a bug that can't use use-simple-atom in react v16.x environments.
- update README.md

## Fix a bug that can't use use-simple-atom in react v16.x environments.
- fix to use `createElement` in AtomStoreProvider instead of JSX

