### PR TITLE
Add useMergeAtom

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,39 @@ export const getStaticProps: GetStaticProps = () => {
 };
 ```
 
+Alternatively, you can use the `useMergeAtom` hooks.
+
+
+```tsx
+import type { GetStaticProps, NextPage } from 'next';
+import { createAtom, useAtomState, useMergeAtom } from 'use-light-atom';
+
+const countAtom = createAtom('counter', 0);
+
+const CounterPage: NextPage = ({ preloadValues }) => {
+  useMergeAtom(countAtom, () => preloadValues.counter)
+  const count = useAtomState(countAtom);
+
+  return (
+    <div>
+      <p>Counter: {count}</p>
+    </div>
+  );
+};
+
+export default CounterPage;
+
+export const getStaticProps: GetStaticProps = () => {
+  return {
+    props: {
+      preloadValues: {
+        [countAtom.key]: 100,
+      },
+    },
+  };
+};
+```
+
 ## API
 ### `useAtom` hooks
 
@@ -377,6 +410,24 @@ const atomStore = useAtomStore()
 ```
 
 `useAtomStore` is a hooks that get store in `AtomStoreProvider`.
+---
+
+### `useMergeAtom` hooks
+
+```tsx
+useMergeAtom(atom, mergeFn)
+```
+
+`useMergeAtom` is a hooks that synchronously rewrites the value of atom.
+Whenever the value of the atom argument is updated, the `mergeFn` function will be executed.
+
+#### Arguments
+- `atom` (type: `Atom<T>`)
+  - Atom created by `createAtom` API.
+
+- `mergeFn` (type: `(prevState: T) => T | undefined`)
+  - If it returns `T`, it will apply the update as the value of atom.
+  - If it returns `undefined`, no update will be performed.
 
 ## License
 [MIT © kqito](./LICENSE)

--- a/examples/next-basic/pages/count-init.tsx
+++ b/examples/next-basic/pages/count-init.tsx
@@ -2,13 +2,26 @@ import Link from 'next/link';
 import type { GetStaticProps, NextPage } from 'next';
 import { countAtom, Counter } from '.';
 import styles from '../styles/Home.module.css';
+import { useMergeAtom } from '../dist';
+import { useCallback } from 'react';
 
-const CounterPage: NextPage = () => {
+type PreloadValues = {
+  preloadValues: {
+    [key: string]: number;
+  };
+};
+
+const CounterPage: NextPage<PreloadValues> = ({ preloadValues }) => {
+  const count = preloadValues[countAtom.key];
+  const setter = useCallback(() => 0, [count]);
+
+  useMergeAtom(countAtom, setter);
+
   return (
     <div className={styles.container}>
       <main className={styles.main}>
         <h1 className={styles.title}>use-light-atom example</h1>
-        <h3>Preload value 100 to count atom</h3>
+        <h3>Reset count atom</h3>
 
         <Link href="/">
           <a>To count app</a>
@@ -26,7 +39,7 @@ export const getStaticProps: GetStaticProps = () => {
   return {
     props: {
       preloadValues: {
-        [countAtom.key]: 100,
+        [countAtom.key]: 0,
       },
     },
   };

--- a/examples/next-basic/pages/index.tsx
+++ b/examples/next-basic/pages/index.tsx
@@ -56,7 +56,7 @@ const CounterPage: NextPage = () => {
         <h3>Count App</h3>
 
         <Link href="/count-init">
-          <a>To count app</a>
+          <a>To Reset count page</a>
         </Link>
 
         <Counter />
@@ -78,3 +78,13 @@ const CounterPage: NextPage = () => {
 };
 
 export default CounterPage;
+
+export const getStaticProps: GetStaticProps = () => {
+  return {
+    props: {
+      preloadValues: {
+        [countAtom.key]: 5,
+      },
+    },
+  };
+};

--- a/examples/next-basic/styles/globals.css
+++ b/examples/next-basic/styles/globals.css
@@ -6,11 +6,6 @@ body {
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
 * {
   box-sizing: border-box;
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@storybook/react": "^6.2.9",
     "@testing-library/jest-dom": "^5.11.10",
     "@testing-library/react": "^12.1.2",
-    "@testing-library/react-hooks": "^5.1.1",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^26.0.22",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-light-atom",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A simple atom-based state management for react",
   "keywords": [
     "react",

--- a/src/core/atom/atom.ts
+++ b/src/core/atom/atom.ts
@@ -6,11 +6,10 @@ export type Atom<T> = {
   isPreload: boolean;
   options: AtomOptions;
 };
-
+export type AtomValue<T> = T extends Atom<infer U> ? U : never;
 export type AtomOptions = {
   equalFn: EqualFn;
 };
-
 export type CreateAtom = {
   <T>(key: string, value: T, atomOptions?: Partial<AtomOptions>): Atom<T>;
 };

--- a/src/core/atomStore/atomStore.tsx
+++ b/src/core/atomStore/atomStore.tsx
@@ -28,6 +28,12 @@ class AtomStore implements IAtomStore {
     const newAtom = atom;
     const storedAtom = this.atoms.get(atom.key) as Atom<T> | undefined;
 
+    // If already stored atom that is not isPreload, return current stored atom.
+    if (storedAtom?.isPreload === false && newAtom.isPreload) {
+      return storedAtom;
+    }
+
+    // If already stored atom that is ot isPreload, then merge atom, return it.
     if (!newAtom.isPreload && storedAtom?.isPreload) {
       newAtom.value = storedAtom.value;
       newAtom.isPreload = false;

--- a/src/core/hooks/useAtom.test.tsx
+++ b/src/core/hooks/useAtom.test.tsx
@@ -1,52 +1,19 @@
-import { ReactElement, useEffect } from 'react';
-import { renderToString } from 'react-dom/server';
 import { getByTestId } from '@testing-library/dom';
-import { render } from '@testing-library/react';
 import { createAtom, createPreloadAtom } from '../atom/atom';
 import { useAtom } from './useAtom';
 import { AtomStoreProvider } from '../atomStore/AtomStoreProvider';
-import * as useIsomorphicLayoutEffectObject from '../../utils/useIsomorphicLayoutEffect';
 import { useIsomorphicLayoutEffect } from '../../utils/useIsomorphicLayoutEffect';
 import { useAtomSetState } from './useAtomSetState';
 import { createAtomStore } from '../atomStore/atomStore';
 import deepEqual from 'fast-deep-equal';
-
-const useIsomorphicLayoutEffectMock = jest.spyOn(
-  useIsomorphicLayoutEffectObject,
-  'useIsomorphicLayoutEffect'
-);
-
-type TestTarget = () => {
-  root: ReactElement;
-  expects: (container: HTMLElement) => void;
-};
-
-const expectRenderResult = (target: TestTarget) => {
-  it('CSR', () => {
-    useIsomorphicLayoutEffectMock.mockImplementation(useEffect);
-    const { root, expects } = target();
-    const { container } = render(root);
-
-    expects(container);
-  });
-
-  it('SSR', () => {
-    useIsomorphicLayoutEffectMock.mockImplementation((effect) => effect());
-
-    const { root, expects } = target();
-    const innerElement = renderToString(root);
-
-    const container = document.createElement('div');
-    container.innerHTML = innerElement;
-
-    expects(container);
-  });
-};
+import {
+  TestTarget,
+  expectRenderResult,
+} from '../../testUtils/expectRenderResult';
 
 describe('useAtom', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    useIsomorphicLayoutEffectMock.mockClear();
   });
 
   describe('Initial state', () => {

--- a/src/core/hooks/useAtomSetState.ts
+++ b/src/core/hooks/useAtomSetState.ts
@@ -4,7 +4,8 @@ import { Atom } from '../atom/atom';
 import { isProduction } from '../../utils/isProduction';
 import { isCallable } from '../../utils/isCallable';
 
-export type SetState<T> = (setter: ((state: T) => T) | T) => void;
+export type Setter<T> = ((state: T) => T) | T;
+export type SetState<T> = (setter: Setter<T>) => void;
 
 export const useAtomSetState = <T>(atom: Atom<T>) => {
   const atomStore = useContext(AtomStoreContext);

--- a/src/core/hooks/useMergeAtom.test.tsx
+++ b/src/core/hooks/useMergeAtom.test.tsx
@@ -1,0 +1,86 @@
+import { createAtom } from '../atom/atom';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useMergeAtom } from './useMergeAtom';
+import { AtomStoreProvider } from '../atomStore/AtomStoreProvider';
+import { useCallback } from 'react';
+import { useAtom } from './useAtom';
+
+describe('useMergeAtom', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('Should override new value to an atom', async () => {
+    type User = {
+      name: string;
+      age: number;
+    };
+    const userAtom = createAtom<User>('user', {
+      name: '',
+      age: -1,
+    });
+
+    const originalAtom = { ...userAtom };
+
+    const { result } = renderHook(
+      () => {
+        const callback = useCallback((prev: User) => {
+          if (prev.name !== '') {
+            return;
+          }
+
+          return { name: 'name', age: 22 };
+        }, []);
+
+        useMergeAtom(userAtom, callback);
+
+        const [state, setState] = useAtom(userAtom);
+
+        return { state, setState };
+      },
+      {
+        wrapper: AtomStoreProvider,
+      }
+    );
+
+    expect(userAtom).toEqual({
+      ...originalAtom,
+      value: {
+        name: 'name',
+        age: 22,
+      },
+    });
+
+    expect(result.current.state).toEqual({
+      name: 'name',
+      age: 22,
+    });
+
+    act(() => {
+      // Test after with rerender
+      result.current.setState((prev) => ({
+        ...prev,
+        name: 'newName',
+      }));
+    });
+
+    expect(userAtom).toEqual({
+      ...originalAtom,
+      value: {
+        name: 'newName',
+        age: 22,
+      },
+    });
+  });
+
+  test('Should not override when setter is undefined', () => {
+    const userAtom = createAtom('user', {
+      name: '',
+      age: -1,
+    });
+
+    renderHook(() => useMergeAtom(userAtom, () => undefined));
+
+    expect(userAtom).toEqual(userAtom);
+  });
+});

--- a/src/core/hooks/useMergeAtom.ts
+++ b/src/core/hooks/useMergeAtom.ts
@@ -1,0 +1,19 @@
+import { useMemo } from 'react';
+import { useAtom } from '..';
+import { Atom } from '../atom/atom';
+
+export type Merge<T> = (prev: T) => T | undefined;
+export type UseMergeAtom = <T>(atom: Atom<T>, merge: Merge<T>) => void;
+
+export const useMergeAtom: UseMergeAtom = (atom, merge) => {
+  const [state, setState] = useAtom(atom);
+
+  useMemo(() => {
+    const nextState = merge(state);
+    if (nextState === undefined) {
+      return;
+    }
+
+    setState(nextState);
+  }, [merge, setState, state]);
+};

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,13 +3,21 @@ export { useAtom } from './hooks/useAtom';
 export { useAtomState } from './hooks/useAtomState';
 export { useAtomSetState } from './hooks/useAtomSetState';
 export { useAtomStore } from './hooks/useAtomStore';
+export { useMergeAtom } from './hooks/useMergeAtom';
 export { createAtomStore } from './atomStore/atomStore';
 export { AtomStoreProvider } from './atomStore/AtomStoreProvider';
 
 // types
-export type { Atom, CreateAtom } from './atom/atom';
+export type {
+  Atom,
+  AtomValue,
+  AtomOptions,
+  EqualFn,
+  CreateAtom,
+} from './atom/atom';
 export type { UseAtom, UseAtomOptions } from './hooks/useAtom';
 export type { UseAtomState, UseAtomStateOptions } from './hooks/useAtomState';
-export type { SetState } from './hooks/useAtomSetState';
+export type { SetState, Setter } from './hooks/useAtomSetState';
+export type { UseMergeAtom, Merge } from './hooks/useMergeAtom';
 export type { Listener, IAtomStore } from './atomStore/atomStore';
 export type { AtomStoreProviderProps } from './atomStore/AtomStoreProvider';

--- a/src/testUtils/expectRenderResult.ts
+++ b/src/testUtils/expectRenderResult.ts
@@ -1,0 +1,36 @@
+import * as useIsomorphicLayoutEffectObject from '../utils/useIsomorphicLayoutEffect';
+import { ReactElement, useLayoutEffect } from 'react';
+import { renderToString } from 'react-dom/server';
+import { render } from '@testing-library/react';
+
+export const useIsomorphicLayoutEffectMock = jest.spyOn(
+  useIsomorphicLayoutEffectObject,
+  'useIsomorphicLayoutEffect'
+);
+
+export type TestTarget = () => {
+  root: ReactElement;
+  expects: (container: HTMLElement) => void;
+};
+
+export const expectRenderResult = (target: TestTarget) => {
+  it('CSR', () => {
+    useIsomorphicLayoutEffectMock.mockImplementation(useLayoutEffect);
+    const { root, expects } = target();
+    const { container } = render(root);
+
+    expects(container);
+  });
+
+  it('SSR', () => {
+    useIsomorphicLayoutEffectMock.mockImplementation((effect) => effect());
+
+    const { root, expects } = target();
+    const innerElement = renderToString(root);
+
+    const container = document.createElement('div');
+    container.innerHTML = innerElement;
+
+    expects(container);
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2404,16 +2404,15 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^5.1.1":
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.3.tgz#f722cc526025be2c16966a9a081edf47a2528721"
-  integrity sha512-UdEUtlQapQ579NEcXDAUE275u+KUsPtxW7NmFrNt0bE6lW8lqNCyxDK0RSuECmNZ/S0/fgP00W9RWRhVKO/hRg==
+"@testing-library/react-hooks@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
+  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/react" ">=16.9.0"
     "@types/react-dom" ">=16.9.0"
     "@types/react-test-renderer" ">=16.9.0"
-    filter-console "^0.1.1"
     react-error-boundary "^3.1.0"
 
 "@testing-library/react@^12.1.2":
@@ -5775,11 +5774,6 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
-
-filter-console@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
-  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 finalhandler@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Overview
- Add `useMergeAtom` hooks
- Update README.md
- Add some useful types

## About `useMergeAtom hooks
`useMergeAtom` is a hooks that synchronously rewrites the value of atom.
Whenever the value of the atom argument is updated, the `mergeFn` function will be executed.