### PR TITLE
Add isDebugMode options to AtomStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,8 +390,14 @@ same as `createAtom`
 ### `createAtomStore` function
 
 ```tsx
-const atomStore = createAtomStore()
+const atomStore = createAtomStore({ isDebugMode })
 ```
+
+#### Arguments
+- `isDebugMode` (type: `boolean`)
+  - Default is `false`
+  - If set `true`, `use-light-atom` will output error when encounter some errors.
+
 
 `createAtomStore` is a function that creates a store. It is mainly used for SSR.
 

--- a/examples/next-basic/pages/_app.tsx
+++ b/examples/next-basic/pages/_app.tsx
@@ -18,7 +18,7 @@ export const StoreInfo = () => {
 function MyApp({ Component, pageProps }: AppProps) {
   const { preloadValues } = pageProps;
 
-  const atomStoreRef = useRef(createAtomStore());
+  const atomStoreRef = useRef(createAtomStore({ isDebugMode: true }));
 
   return (
     <>

--- a/src/core/atom/atom.ts
+++ b/src/core/atom/atom.ts
@@ -3,10 +3,14 @@ export type EqualFn = (a: any, b: any) => boolean;
 export type Atom<T> = {
   key: string;
   value: T;
-  isPreload: boolean;
   options: AtomOptions;
+  meta: AtomMeta<T>;
 };
 export type AtomValue<T> = T extends Atom<infer U> ? U : never;
+export type AtomMeta<T> = {
+  isPreload: boolean;
+  initialValue: T;
+};
 export type AtomOptions = {
   equalFn: EqualFn;
 };
@@ -19,7 +23,10 @@ export const createBaseAtom =
   (key, value, { equalFn = Object.is } = {}) => ({
     key,
     value,
-    isPreload,
+    meta: {
+      isPreload,
+      initialValue: value,
+    },
     options: {
       equalFn,
     },

--- a/src/core/atom/atom.ts
+++ b/src/core/atom/atom.ts
@@ -4,12 +4,12 @@ export type Atom<T> = {
   key: string;
   value: T;
   options: AtomOptions;
-  meta: AtomMeta<T>;
+  meta: AtomMeta;
 };
 export type AtomValue<T> = T extends Atom<infer U> ? U : never;
-export type AtomMeta<T> = {
+export type AtomMeta = {
   isPreload: boolean;
-  initialValue: T;
+  initialValue: string;
 };
 export type AtomOptions = {
   equalFn: EqualFn;
@@ -25,7 +25,8 @@ export const createBaseAtom =
     value,
     meta: {
       isPreload,
-      initialValue: value,
+      initialValue:
+        typeof value === 'object' ? JSON.stringify(value) : String(value),
     },
     options: {
       equalFn,

--- a/src/core/atomStore/AtomStoreContext.ts
+++ b/src/core/atomStore/AtomStoreContext.ts
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+import { IAtomStore, createAtomStore } from '..';
+
+export const AtomStoreContext = createContext<IAtomStore>(createAtomStore());

--- a/src/core/atomStore/AtomStoreContext.ts
+++ b/src/core/atomStore/AtomStoreContext.ts
@@ -1,4 +1,4 @@
 import { createContext } from 'react';
-import { IAtomStore, createAtomStore } from '..';
+import { IAtomStore, createAtomStore } from './atomStore';
 
 export const AtomStoreContext = createContext<IAtomStore>(createAtomStore());

--- a/src/core/atomStore/AtomStoreProvider.ts
+++ b/src/core/atomStore/AtomStoreProvider.ts
@@ -1,6 +1,7 @@
 import { createElement, FC, useMemo, useRef } from 'react';
 import { createPreloadAtom } from '../atom/atom';
-import { createAtomStore, IAtomStore, AtomStoreContext } from './atomStore';
+import { createAtomStore, IAtomStore } from './atomStore';
+import { AtomStoreContext } from './AtomStoreContext';
 
 export type AtomStoreProviderProps = Readonly<{
   atomStore?: IAtomStore;

--- a/src/core/atomStore/atomStore.test.ts
+++ b/src/core/atomStore/atomStore.test.ts
@@ -1,0 +1,85 @@
+import { createAtom } from '../atom/atom';
+import { createAtomStore } from './atomStore';
+import * as devLogObject from '../../utils/devlog';
+
+describe('atomStore', () => {
+  const spyOnDevlog = jest
+    .spyOn(devLogObject, 'devlog')
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    .mockImplementation(() => {});
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('Register atoms', () => {
+    const userAtom = createAtom('user', {
+      name: 'example',
+      age: 22,
+    });
+
+    const counterAtom = createAtom('counter', 0);
+
+    const atomStore = createAtomStore();
+
+    expect(atomStore.getAtoms()).toEqual({});
+
+    expect(atomStore.setAtom(userAtom)).toEqual(userAtom);
+    expect(atomStore.getAtoms()).toEqual({
+      [userAtom.key]: userAtom,
+    });
+
+    expect(atomStore.setAtom(counterAtom)).toEqual(counterAtom);
+    expect(atomStore.getAtoms()).toEqual({
+      [userAtom.key]: userAtom,
+      [counterAtom.key]: counterAtom,
+    });
+  });
+
+  test('Try to Register duplicated atoms has same key and not same value', () => {
+    const user1Atom = createAtom('user', {
+      name: 'example1',
+      age: 22,
+    });
+
+    const user2Atom = createAtom('user', {
+      name: 'example2',
+      age: 22,
+    });
+
+    const atomStore = createAtomStore({ isDebugMode: true });
+
+    expect(atomStore.setAtom(user1Atom)).toEqual(user1Atom);
+    expect(atomStore.getAtoms()).toEqual({
+      [user1Atom.key]: user1Atom,
+    });
+    expect(spyOnDevlog).toBeCalledTimes(0);
+
+    expect(atomStore.setAtom(user2Atom)).toEqual(user1Atom);
+    expect(atomStore.getAtoms()).toEqual({
+      [user1Atom.key]: user1Atom,
+    });
+    expect(spyOnDevlog).toBeCalledTimes(1);
+  });
+
+  test('Try to Register duplicated atoms has same key and value', () => {
+    const userAtom = createAtom('user', {
+      name: 'example1',
+      age: 22,
+    });
+
+    const atomStore = createAtomStore({ isDebugMode: true });
+
+    expect(atomStore.setAtom(userAtom)).toEqual(userAtom);
+    expect(atomStore.getAtoms()).toEqual({
+      [userAtom.key]: userAtom,
+    });
+    expect(spyOnDevlog).toBeCalledTimes(0);
+
+    expect(atomStore.setAtom(userAtom)).toEqual(userAtom);
+    expect(atomStore.getAtoms()).toEqual({
+      [userAtom.key]: userAtom,
+    });
+    expect(spyOnDevlog).toBeCalledTimes(0);
+  });
+});

--- a/src/core/atomStore/atomStore.tsx
+++ b/src/core/atomStore/atomStore.tsx
@@ -1,4 +1,3 @@
-import { createContext } from 'react';
 import { Atom } from '../atom/atom';
 
 export type Listener = (atom: Atom<unknown>) => void;
@@ -77,5 +76,3 @@ class AtomStore implements IAtomStore {
 }
 
 export const createAtomStore = () => new AtomStore();
-
-export const AtomStoreContext = createContext<IAtomStore>(createAtomStore());

--- a/src/core/hooks/useAtomSetState.ts
+++ b/src/core/hooks/useAtomSetState.ts
@@ -1,8 +1,8 @@
 import { useCallback, useContext } from 'react';
 import { Atom } from '../atom/atom';
-import { isProduction } from '../../utils/isProduction';
 import { isCallable } from '../../utils/isCallable';
 import { AtomStoreContext } from '../atomStore/AtomStoreContext';
+import { devlog } from '../../utils/devlog';
 
 export type Setter<T> = ((state: T) => T) | T;
 export type SetState<T> = (setter: Setter<T>) => void;
@@ -15,10 +15,7 @@ export const useAtomSetState = <T>(atom: Atom<T>) => {
       const storedAtom = atomStore.setAtom<T>(atom);
 
       if (storedAtom === undefined) {
-        if (!isProduction) {
-          throw new Error(`${atom.key}'s atom has not stored.'`);
-        }
-
+        devlog(`${atom.key}'s atom has not stored.'`, 'error');
         return;
       }
 

--- a/src/core/hooks/useAtomSetState.ts
+++ b/src/core/hooks/useAtomSetState.ts
@@ -1,8 +1,8 @@
 import { useCallback, useContext } from 'react';
-import { AtomStoreContext } from '../atomStore/atomStore';
 import { Atom } from '../atom/atom';
 import { isProduction } from '../../utils/isProduction';
 import { isCallable } from '../../utils/isCallable';
+import { AtomStoreContext } from '../atomStore/AtomStoreContext';
 
 export type Setter<T> = ((state: T) => T) | T;
 export type SetState<T> = (setter: Setter<T>) => void;

--- a/src/core/hooks/useAtomState.ts
+++ b/src/core/hooks/useAtomState.ts
@@ -1,9 +1,10 @@
 import { useCallback, useContext, useMemo, useRef, useState } from 'react';
-import { Listener, AtomStoreContext } from '../atomStore/atomStore';
+import { Listener } from '../atomStore/atomStore';
 import { Atom, EqualFn } from '../atom/atom';
 import { Selector, useFunctionRef } from '../../utils/useFunctionRef';
 import { useIsomorphicLayoutEffect } from '../../utils/useIsomorphicLayoutEffect';
 import { isProduction } from '../../utils/isProduction';
+import { AtomStoreContext } from '../atomStore/AtomStoreContext';
 
 export type UseAtomStateOptions<T, S> = {
   selector?: Selector<T, S>;

--- a/src/core/hooks/useAtomState.ts
+++ b/src/core/hooks/useAtomState.ts
@@ -3,8 +3,8 @@ import { Listener } from '../atomStore/atomStore';
 import { Atom, EqualFn } from '../atom/atom';
 import { Selector, useFunctionRef } from '../../utils/useFunctionRef';
 import { useIsomorphicLayoutEffect } from '../../utils/useIsomorphicLayoutEffect';
-import { isProduction } from '../../utils/isProduction';
 import { AtomStoreContext } from '../atomStore/AtomStoreContext';
+import { devlog } from '../../utils/devlog';
 
 export type UseAtomStateOptions<T, S> = {
   selector?: Selector<T, S>;
@@ -54,11 +54,7 @@ export const useAtomState: UseAtomState = <T, S>(
         prevStateRef.current = newState;
         setState(newState);
       } catch (err) {
-        if (isProduction) {
-          return;
-        }
-
-        console.error(err);
+        devlog(err, 'error');
       }
     };
 

--- a/src/core/hooks/useAtomStore.ts
+++ b/src/core/hooks/useAtomStore.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
-import { AtomStoreContext, IAtomStore } from '../atomStore/atomStore';
+import { IAtomStore } from '../atomStore/atomStore';
+import { AtomStoreContext } from '../atomStore/AtomStoreContext';
 
 export const useAtomStore = (): IAtomStore => {
   return useContext(AtomStoreContext);

--- a/src/core/hooks/useMergeAtom.ts
+++ b/src/core/hooks/useMergeAtom.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useAtom } from '..';
+import { useAtom } from '../hooks/useAtom';
 import { Atom } from '../atom/atom';
 
 export type Merge<T> = (prev: T) => T | undefined;

--- a/src/utils/devlog.ts
+++ b/src/utils/devlog.ts
@@ -1,0 +1,11 @@
+import { isProduction } from './isProduction';
+
+type LogType = 'log' | 'warn' | 'error';
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const devlog = (message: any, type: LogType) => {
+  if (isProduction) {
+    return;
+  }
+
+  console[type](message);
+};


### PR DESCRIPTION
## Overview
- add `isDebugMode` option

## `isDebugMode` option
- If set `true`, `use-light-atom` will output error when encounter some errors.
- Default is `false`


example
```tsx
const atomStore = createAtomStore({ isDebugMode: true })
```