### PR TITLE
Remove atom key

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We can use `use-light-atom` as following.
 ```tsx
 import { AtomStoreProvider, useAtom, createAtom } from 'use-light-atom'
 
-export const counterAtom = createAtom('counter', {
+export const counterAtom = createAtom({
   count: 0
 });
 
@@ -84,11 +84,11 @@ We can use the state and the function to update it from atom as follows
 ```tsx
 import { useAtom, createAtom } from 'use-light-atom'
 
-export const counterAtom = createAtom('counter', {
+export const counterAtom = createAtom({
   count: 0
 });
 
-export const userAtom = createAtom('userInfomation', {
+export const userAtom = createAtom({
   age: 22,
   name: 'kqito'
 });
@@ -121,7 +121,7 @@ If specify `selector`, we can extract only the necessary values from the atom
 ```tsx
 import { useAtomState, createAtom } from 'use-light-atom'
 
-export const userAtom = createAtom('userInfomation', {
+export const userAtom = createAtom({
   age: 22,
   name: 'kqito'
 });
@@ -145,10 +145,7 @@ If you want to change the equal function, you can specify the equalFn option. (d
 ```tsx
 import { useAtomState, createAtom } from 'use-light-atom'
 
-export const counterAtom = createAtom('counter',
-  {
-    count: 0
-  },
+export const counterAtom = createAtom({ count: 0 },
   {
     // we can specify default equalFn
     equalFn: deepEqual
@@ -195,7 +192,7 @@ Next, the pages component file you want to SG should look like this
 import type { GetStaticProps, NextPage } from 'next';
 import { createAtom, useAtomState } from 'use-light-atom';
 
-const countAtom = createAtom('counter', 0);
+const countAtom = createAtom(0);
 
 const CounterPage: NextPage = () => {
   const count = useAtomState(countAtom);
@@ -227,10 +224,11 @@ Alternatively, you can use the `useMergeAtom` hooks.
 import type { GetStaticProps, NextPage } from 'next';
 import { createAtom, useAtomState, useMergeAtom } from 'use-light-atom';
 
-const countAtom = createAtom('counter', 0);
+const countAtom = createAtom(0);
 
 const CounterPage: NextPage = ({ preloadValues }) => {
-  useMergeAtom(countAtom, () => preloadValues.counter)
+const setter = useCallback(() => preloadValues.counter, [preloadValues.counter])
+  useMergeAtom(countAtom, setter)
   const count = useAtomState(countAtom);
 
   return (
@@ -326,15 +324,12 @@ const setState = useAtomState(atom);
 ### `createAtom` function
 
 ```tsx
-const atom = createAtom(key, value, { equalFn });
+const atom = createAtom(value, { equalFn });
 ```
 
 `createAtom` is a function to create atom.
 
 #### Arguments
-- `key` (type: `string`)
-  - The atom key must be unique.
-
 - `value` (type: `T`)
   - Initial value of atom.
 
@@ -343,25 +338,6 @@ const atom = createAtom(key, value, { equalFn });
   - Default is `Object.is`.
   - A function that compares the current value of store with the value of store when it changes.
   - If the return value is true, re-rendering will occur.
-
----
-
-### `createPreloadAtom` function
-
-```tsx
-const atom = createPreloadAtom(key, value, { equalFn });
-```
-
-`createPreloadAtom` is a function to create preload atom.
-
-`Preload atom` can be used when you want to use a SSG value as the initial value.
-
-#### Arguments
-same as `createAtom`
-
-#### Returns
-- `atom` (type: `Atom<T>`)
-  - Atom available for useAtom hooks, etc.
 
 ---
 

--- a/examples/next-basic/pages/count-init.tsx
+++ b/examples/next-basic/pages/count-init.tsx
@@ -13,7 +13,7 @@ type PreloadValues = {
 
 const CounterPage: NextPage<PreloadValues> = ({ preloadValues }) => {
   const count = preloadValues[countAtom.key];
-  const setter = useCallback(() => 0, [count]);
+  const setter = useCallback(() => count, [count]);
 
   useMergeAtom(countAtom, setter);
 

--- a/examples/next-basic/pages/index.tsx
+++ b/examples/next-basic/pages/index.tsx
@@ -4,7 +4,7 @@ import styles from '../styles/Home.module.css';
 
 import { createAtom, useAtom, useAtomSetState } from '../dist';
 
-export const countAtom = createAtom('counter', 0);
+export const countAtom = createAtom(0);
 
 export const Counter = () => {
   const [count] = useAtom(countAtom);

--- a/src/core/atom/atom.ts
+++ b/src/core/atom/atom.ts
@@ -8,32 +8,27 @@ export type Atom<T> = {
 };
 export type AtomValue<T> = T extends Atom<infer U> ? U : never;
 export type AtomMeta = {
-  isPreload: boolean;
   initialValue: string;
 };
 export type AtomOptions = {
   equalFn: EqualFn;
 };
-export type CreateAtom = {
-  <T>(key: string, value: T, atomOptions?: Partial<AtomOptions>): Atom<T>;
-};
+export type CreateAtom = <T>(
+  value: T,
+  atomOptions?: Partial<AtomOptions>
+) => Atom<T>;
 
-export const createBaseAtom =
-  ({ isPreload }: { isPreload: boolean }): CreateAtom =>
-  (key, value, { equalFn = Object.is } = {}) => ({
-    key,
-    value,
-    meta: {
-      isPreload,
-      initialValue:
-        typeof value === 'object' ? JSON.stringify(value) : String(value),
-    },
-    options: {
-      equalFn,
-    },
-  });
+let atomNumer = 0;
+const createAtomKey = () => `atom-${atomNumer++}`;
 
-export const createAtom: CreateAtom = (key, value, atomOptions) =>
-  createBaseAtom({ isPreload: false })(key, value, atomOptions);
-export const createPreloadAtom: CreateAtom = (key, value, atomOptions) =>
-  createBaseAtom({ isPreload: true })(key, value, atomOptions);
+export const createAtom: CreateAtom = (value, { equalFn } = {}) => ({
+  key: createAtomKey(),
+  value,
+  meta: {
+    initialValue:
+      typeof value === 'object' ? JSON.stringify(value) : String(value),
+  },
+  options: {
+    equalFn: equalFn || Object.is,
+  },
+});

--- a/src/core/atomStore/AtomStoreProvider.ts
+++ b/src/core/atomStore/AtomStoreProvider.ts
@@ -1,5 +1,4 @@
 import { createElement, FC, useMemo, useRef } from 'react';
-import { createPreloadAtom } from '../atom/atom';
 import { createAtomStore, IAtomStore } from './atomStore';
 import { AtomStoreContext } from './AtomStoreContext';
 
@@ -21,7 +20,7 @@ export const AtomStoreProvider: FC<AtomStoreProviderProps> = ({
     }
 
     for (const [key, preloadValue] of Object.entries(preloadValues)) {
-      storeRef.current.setAtom(createPreloadAtom(key, preloadValue));
+      storeRef.current.setPreloadValue(key, preloadValue);
     }
   }, [preloadValues]);
 

--- a/src/core/atomStore/atomStore.test.ts
+++ b/src/core/atomStore/atomStore.test.ts
@@ -9,12 +9,12 @@ describe('atomStore', () => {
   });
 
   test('Register atoms', () => {
-    const userAtom = createAtom('user', {
+    const userAtom = createAtom({
       name: 'example',
       age: 22,
     });
 
-    const counterAtom = createAtom('counter', 0);
+    const counterAtom = createAtom(0);
 
     const atomStore = createAtomStore();
 
@@ -32,35 +32,8 @@ describe('atomStore', () => {
     });
   });
 
-  test('Try to Register duplicated atoms has same key and not same value', () => {
-    const duplicatedKey = 'user';
-    const user1Atom = createAtom(duplicatedKey, {
-      name: duplicatedKey + '1',
-      age: 22,
-    });
-
-    const user2Atom = createAtom(duplicatedKey, {
-      name: duplicatedKey + '2',
-      age: 22,
-    });
-
-    const atomStore = createAtomStore({ isDebugMode: true });
-
-    expect(atomStore.setAtom(user1Atom)).toEqual(user1Atom);
-    expect(atomStore.getAtoms()).toEqual({
-      [duplicatedKey]: user1Atom,
-    });
-    expect(spyOnDevlog).toBeCalledTimes(0);
-
-    expect(atomStore.setAtom(user2Atom)).toEqual(user2Atom);
-    expect(atomStore.getAtoms()).toEqual({
-      [duplicatedKey]: user2Atom,
-    });
-    expect(spyOnDevlog).toBeCalledTimes(1);
-  });
-
   test('Try to Register duplicated atoms has same key and value', () => {
-    const userAtom = createAtom('user', {
+    const userAtom = createAtom({
       name: 'example1',
       age: 22,
     });

--- a/src/core/atomStore/atomStore.test.ts
+++ b/src/core/atomStore/atomStore.test.ts
@@ -1,13 +1,9 @@
+import { createDevlogMock } from '../../testUtils/devlogMock';
 import { createAtom } from '../atom/atom';
 import { createAtomStore } from './atomStore';
-import * as devLogObject from '../../utils/devlog';
 
 describe('atomStore', () => {
-  const spyOnDevlog = jest
-    .spyOn(devLogObject, 'devlog')
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    .mockImplementation(() => {});
-
+  const spyOnDevlog = createDevlogMock();
   beforeEach(() => {
     jest.resetAllMocks();
   });

--- a/src/core/hooks/useAtom.test.tsx
+++ b/src/core/hooks/useAtom.test.tsx
@@ -1,5 +1,5 @@
 import { getByTestId } from '@testing-library/dom';
-import { createAtom, createPreloadAtom } from '../atom/atom';
+import { createAtom } from '../atom/atom';
 import { useAtom } from './useAtom';
 import { AtomStoreProvider } from '../atomStore/AtomStoreProvider';
 import { useIsomorphicLayoutEffect } from '../../utils/useIsomorphicLayoutEffect';
@@ -19,7 +19,7 @@ describe('useAtom', () => {
   describe('Initial state', () => {
     const testTarget: TestTarget = () => {
       const User = () => {
-        const userAtom = createAtom('user', {
+        const userAtom = createAtom({
           name: 'example',
           age: -1,
         });
@@ -53,7 +53,7 @@ describe('useAtom', () => {
   describe('SetState', () => {
     describe('Dispath with literal', () => {
       const testTarget: TestTarget = () => {
-        const userAtom = createAtom('user', {
+        const userAtom = createAtom({
           name: '',
           age: -1,
         });
@@ -93,11 +93,13 @@ describe('useAtom', () => {
           expects: (container: HTMLElement) => {
             expect(getByTestId(container, 'name').textContent).toBe('example');
             expect(getByTestId(container, 'age').textContent).toBe('22');
-            expect(store.getAtoms().user).toEqual({
-              ...userAtom,
-              value: {
-                name: 'example',
-                age: 22,
+            expect(store.getAtoms()).toEqual({
+              [userAtom.key]: {
+                ...userAtom,
+                value: {
+                  name: 'example',
+                  age: 22,
+                },
               },
             });
           },
@@ -109,7 +111,7 @@ describe('useAtom', () => {
 
     describe('Dispath with function', () => {
       const testTarget: TestTarget = () => {
-        const userAtom = createAtom('user', {
+        const userAtom = createAtom({
           name: '',
           age: -1,
         });
@@ -150,11 +152,13 @@ describe('useAtom', () => {
           expects: (container) => {
             expect(getByTestId(container, 'name').textContent).toBe('example');
             expect(getByTestId(container, 'age').textContent).toBe('22');
-            expect(store.getAtoms().user).toEqual({
-              ...userAtom,
-              value: {
-                name: 'example',
-                age: 22,
+            expect(store.getAtoms()).toEqual({
+              [userAtom.key]: {
+                ...userAtom,
+                value: {
+                  name: 'example',
+                  age: 22,
+                },
               },
             });
           },
@@ -167,7 +171,7 @@ describe('useAtom', () => {
 
   describe('Initial state from store', () => {
     const testTarget: TestTarget = () => {
-      const userAtom = createAtom('user', {
+      const userAtom = createAtom({
         name: '',
         age: -1,
       });
@@ -184,12 +188,10 @@ describe('useAtom', () => {
       };
 
       const atomStore = createAtomStore();
-      atomStore.setAtom(
-        createPreloadAtom('user', {
-          name: 'example',
-          age: 22,
-        })
-      );
+      atomStore.setPreloadValue(userAtom.key, {
+        name: 'example',
+        age: 22,
+      });
 
       return {
         root: (
@@ -210,12 +212,12 @@ describe('useAtom', () => {
   describe('With multi atoms', () => {
     const testTarget: TestTarget = () => {
       const User = () => {
-        const userAtom = createAtom('user', {
+        const userAtom = createAtom({
           name: '',
           age: -1,
         });
 
-        const countAtom = createAtom('count', 0);
+        const countAtom = createAtom(0);
 
         const [name] = useAtom(userAtom, { selector: ({ name }) => name });
         const [age] = useAtom(userAtom, { selector: ({ age }) => age });
@@ -267,7 +269,6 @@ describe('useAtom', () => {
     const testTarget: TestTarget = () => {
       const User = () => {
         const userAtom = createAtom(
-          'user',
           {
             name: '',
             age: -1,
@@ -277,7 +278,7 @@ describe('useAtom', () => {
           }
         );
 
-        const dateAtom = createAtom('date', {
+        const dateAtom = createAtom({
           month: -1,
           date: -1,
         });

--- a/src/core/hooks/useAtomSetState.ts
+++ b/src/core/hooks/useAtomSetState.ts
@@ -1,14 +1,14 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
 import { Atom } from '../atom/atom';
 import { isCallable } from '../../utils/isCallable';
-import { AtomStoreContext } from '../atomStore/AtomStoreContext';
 import { devlog } from '../../utils/devlog';
+import { useAtomStore } from './useAtomStore';
 
 export type Setter<T> = ((state: T) => T) | T;
 export type SetState<T> = (setter: Setter<T>) => void;
 
 export const useAtomSetState = <T>(atom: Atom<T>) => {
-  const atomStore = useContext(AtomStoreContext);
+  const atomStore = useAtomStore();
 
   const setState = useCallback<SetState<T>>(
     (setter) => {

--- a/src/core/hooks/useAtomSetState.ts
+++ b/src/core/hooks/useAtomSetState.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { Atom } from '../atom/atom';
 import { isCallable } from '../../utils/isCallable';
-import { devlog } from '../../utils/devlog';
+import { devWarnLog } from '../../utils/devlog';
 import { useAtomStore } from './useAtomStore';
 
 export type Setter<T> = ((state: T) => T) | T;
@@ -15,7 +15,7 @@ export const useAtomSetState = <T>(atom: Atom<T>) => {
       const storedAtom = atomStore.setAtom<T>(atom);
 
       if (storedAtom === undefined) {
-        devlog(`${atom.key}'s atom has not stored.'`, 'error');
+        devWarnLog(`${atom.key}'s atom has not stored.'`);
         return;
       }
 

--- a/src/core/hooks/useAtomState.ts
+++ b/src/core/hooks/useAtomState.ts
@@ -1,10 +1,10 @@
-import { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { Listener } from '../atomStore/atomStore';
 import { Atom, EqualFn } from '../atom/atom';
 import { Selector, useFunctionRef } from '../../utils/useFunctionRef';
 import { useIsomorphicLayoutEffect } from '../../utils/useIsomorphicLayoutEffect';
-import { AtomStoreContext } from '../atomStore/AtomStoreContext';
 import { devlog } from '../../utils/devlog';
+import { useAtomStore } from './useAtomStore';
 
 export type UseAtomStateOptions<T, S> = {
   selector?: Selector<T, S>;
@@ -20,7 +20,7 @@ export const useAtomState: UseAtomState = <T, S>(
   atom: Atom<T>,
   { selector, equalFn }: UseAtomStateOptions<T, S> = {}
 ) => {
-  const atomStore = useContext(AtomStoreContext);
+  const atomStore = useAtomStore();
   const selectStateRef = useFunctionRef(selector);
   const equalFnRef = useFunctionRef(equalFn);
 

--- a/src/core/hooks/useAtomState.ts
+++ b/src/core/hooks/useAtomState.ts
@@ -3,7 +3,7 @@ import { Listener } from '../atomStore/atomStore';
 import { Atom, EqualFn } from '../atom/atom';
 import { Selector, useFunctionRef } from '../../utils/useFunctionRef';
 import { useIsomorphicLayoutEffect } from '../../utils/useIsomorphicLayoutEffect';
-import { devlog } from '../../utils/devlog';
+import { devWarnLog } from '../../utils/devlog';
 import { useAtomStore } from './useAtomStore';
 
 export type UseAtomStateOptions<T, S> = {
@@ -54,7 +54,7 @@ export const useAtomState: UseAtomState = <T, S>(
         prevStateRef.current = newState;
         setState(newState);
       } catch (err) {
-        devlog(err, 'error');
+        devWarnLog(err);
       }
     };
 

--- a/src/core/hooks/useAtomStore.test.tsx
+++ b/src/core/hooks/useAtomStore.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { AtomStoreProvider } from '../atomStore/AtomStoreProvider';
+import { useAtomStore } from './useAtomStore';
+import { createAtomStore } from '../atomStore/atomStore';
+
+describe('useAtomStore', () => {
+  const atomStore = createAtomStore();
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('Should be able to get AtomStore when AtomStoreProvider is setted on the container', () => {
+    const { result } = renderHook(() => useAtomStore(), {
+      wrapper: ({ children }) => (
+        <AtomStoreProvider atomStore={atomStore}>{children}</AtomStoreProvider>
+      ),
+    });
+
+    expect(result.current).toEqual(atomStore);
+  });
+
+  test('Should be able to get AtomStore when no AtomStoreProvider is setted on the container', () => {
+    const { result } = renderHook(() => useAtomStore());
+
+    expect(result.current).toEqual(atomStore);
+  });
+});

--- a/src/core/hooks/useAtomStore.ts
+++ b/src/core/hooks/useAtomStore.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { devlog } from '../../utils/devlog';
+import { devWarnLog } from '../../utils/devlog';
 import { IAtomStore } from '../atomStore/atomStore';
 import { AtomStoreContext } from '../atomStore/AtomStoreContext';
 
@@ -7,9 +7,8 @@ export const useAtomStore = (): IAtomStore => {
   const atomStore = useContext(AtomStoreContext);
 
   if (atomStore === null) {
-    devlog(
-      `'AtomStoreProvider' has not found. Please check to set 'AtomStoreProvider' on the parent element or higher`,
-      'warn'
+    devWarnLog(
+      `'AtomStoreProvider' has not found. Please check to set 'AtomStoreProvider' on the parent element or higher`
     );
   }
 

--- a/src/core/hooks/useAtomStore.ts
+++ b/src/core/hooks/useAtomStore.ts
@@ -1,7 +1,17 @@
 import { useContext } from 'react';
+import { devlog } from '../../utils/devlog';
 import { IAtomStore } from '../atomStore/atomStore';
 import { AtomStoreContext } from '../atomStore/AtomStoreContext';
 
 export const useAtomStore = (): IAtomStore => {
-  return useContext(AtomStoreContext);
+  const atomStore = useContext(AtomStoreContext);
+
+  if (atomStore === null) {
+    devlog(
+      `'AtomStoreProvider' has not found. Please check to set 'AtomStoreProvider' on the parent element or higher`,
+      'warn'
+    );
+  }
+
+  return atomStore;
 };

--- a/src/core/hooks/useMergeAtom.test.tsx
+++ b/src/core/hooks/useMergeAtom.test.tsx
@@ -15,7 +15,7 @@ describe('useMergeAtom', () => {
       name: string;
       age: number;
     };
-    const userAtom = createAtom<User>('user', {
+    const userAtom = createAtom<User>({
       name: '',
       age: -1,
     });
@@ -74,7 +74,7 @@ describe('useMergeAtom', () => {
   });
 
   test('Should not override when setter is undefined', () => {
-    const userAtom = createAtom('user', {
+    const userAtom = createAtom({
       name: '',
       age: -1,
     });

--- a/src/core/hooks/useMergeAtom.ts
+++ b/src/core/hooks/useMergeAtom.ts
@@ -15,5 +15,6 @@ export const useMergeAtom: UseMergeAtom = (atom, merge) => {
     }
 
     setState(nextState);
-  }, [merge, setState, state]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [merge]);
 };

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,4 @@
-export { createAtom, createPreloadAtom } from './atom/atom';
+export { createAtom } from './atom/atom';
 export { useAtom } from './hooks/useAtom';
 export { useAtomState } from './hooks/useAtomState';
 export { useAtomSetState } from './hooks/useAtomSetState';

--- a/src/testUtils/devlogMock.ts
+++ b/src/testUtils/devlogMock.ts
@@ -1,0 +1,10 @@
+import * as devLogObject from '../utils/devlog';
+
+export const createDevlogMock = () => {
+  return (
+    jest
+      .spyOn(devLogObject, 'devlog')
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .mockImplementation(() => {})
+  );
+};

--- a/src/testUtils/devlogMock.ts
+++ b/src/testUtils/devlogMock.ts
@@ -3,7 +3,7 @@ import * as devLogObject from '../utils/devlog';
 export const createDevlogMock = () => {
   return (
     jest
-      .spyOn(devLogObject, 'devlog')
+      .spyOn(devLogObject, 'devWarnLog')
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       .mockImplementation(() => {})
   );

--- a/src/utils/devlog.ts
+++ b/src/utils/devlog.ts
@@ -1,11 +1,10 @@
 import { isProduction } from './isProduction';
 
-type LogType = 'log' | 'warn' | 'error';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const devlog = (message: any, type: LogType) => {
+export const devWarnLog = (...message: any) => {
   if (isProduction) {
     return;
   }
 
-  console[type](message);
+  console.warn(...message);
 };


### PR DESCRIPTION
## Overview
- Remove atom key
- Update README.md
- Remove `createPreloadAtom` function

## Remove atom key
we can create atom be `createAtom` function without specify `key`

before
```tsx
const counterAtom = createAtom('counter', 0)
```

after
```tsx
const counterAtom = createAtom(0)
```

This is inspired by [jotai](https://www.google.com/search?q=jotai&oq=jotai&aqs=chrome.0.69i59j0i4i512l4j69i60l3.446j0j7&sourceid=chrome&ie=UTF-8)

### Remove `createPreloadAtom` function
This reason for that this can no longer be specified `key` explicitly. so, we can use `useMergeAtom` or `atomStore.setPreloadValue` altenatively method