### PR TITLE
Change atom interface for indicating it has side-effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,39 +201,7 @@ export const Counter = () => {
 
 ### Static Generation with Next.js
 
-At first, pages component file you want to SG should look like this
-
-
-```tsx
-import type { GetStaticProps, NextPage } from 'next';
-import { createAtom, useAtomState } from 'use-light-atom';
-
-const countAtom = createAtom(0);
-
-const CounterPage: NextPage = () => {
-  const count = useAtomState(countAtom);
-
-  return (
-    <div>
-      <p>Counter: {count}</p>
-    </div>
-  );
-};
-
-export default CounterPage;
-
-export const getStaticProps: GetStaticProps = () => {
-  return {
-    props: {
-      preloadValues: {
-        [countAtom.key]: 100,
-      },
-    },
-  };
-};
-```
-
-Next, you can use the `useMergeAtom` hooks as following.
+We can use the `useMergeAtom` hooks for SSR as following.
 
 
 ```tsx

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ export const DataDisplayer = () => {
 
 ```tsx
 // DataDisplayer will return null
-dataAtom.value = undefined
+dataAtom.setValue(undefined)
 
 // DataDisplayer will return 'hogehoge' with rerender
-dataAtom.value = 'hogehoge'
+dataAtom.setValue('hogehoge')
 ```
 
 
@@ -147,7 +147,7 @@ counterAtom.subscribe((counter: number) => {
 })
 
 // counterAtom will output 'count is 100 now' log
-counterAtom.value = 100
+counterAtom.setValue(100)
 ```
 
 

--- a/src/core/atom/atom.test.ts
+++ b/src/core/atom/atom.test.ts
@@ -9,8 +9,8 @@ describe('atom', () => {
       { equalFn: deepEqual }
     );
 
-    expect(countAtom.value).toBe(0);
-    expect(userWithEqualFnAtom.value).toEqual({ name: 'John', age: 22 });
+    expect(countAtom.getValue()).toBe(0);
+    expect(userWithEqualFnAtom.getValue()).toEqual({ name: 'John', age: 22 });
     expect(userWithEqualFnAtom.options.equalFn).toEqual(deepEqual);
   });
 
@@ -21,22 +21,22 @@ describe('atom', () => {
     countAtom.subscribe(mockFn);
 
     const newNumber1 = 100;
-    countAtom.value = newNumber1;
+    countAtom.setValue(newNumber1);
 
-    expect(countAtom.value).toBe(newNumber1);
+    expect(countAtom.getValue()).toBe(newNumber1);
     expect(mockFn).toBeCalledTimes(1);
 
     const newNumber2 = 1000;
-    countAtom.value = newNumber2;
+    countAtom.setValue(newNumber2);
 
-    expect(countAtom.value).toBe(newNumber2);
+    expect(countAtom.getValue()).toBe(newNumber2);
     expect(mockFn).toBeCalledTimes(2);
 
     countAtom.unsubscribe(mockFn);
     const newNumber3 = 10000;
-    countAtom.value = newNumber3;
+    countAtom.setValue(newNumber3);
 
-    expect(countAtom.value).toBe(newNumber3);
+    expect(countAtom.getValue()).toBe(newNumber3);
     expect(mockFn).toBeCalledTimes(2);
   });
 });

--- a/src/core/atom/atom.ts
+++ b/src/core/atom/atom.ts
@@ -2,7 +2,8 @@
 export type EqualFn = (a: any, b: any) => boolean;
 export type Listener<T> = (value: T) => void;
 export interface IAtom<T> {
-  value: T;
+  getValue: () => T;
+  setValue: (value: T) => void;
   options: AtomOptions;
   subscribe: (listener: Listener<T>) => void;
   unsubscribe: (listener: Listener<T>) => void;
@@ -17,9 +18,9 @@ export type CreateAtom = <T>(
 ) => Atom<T>;
 
 class Atom<T> implements IAtom<T> {
+  public options: AtomOptions;
   private __value: T;
   private __listeners: Array<Listener<T>>;
-  public options: AtomOptions;
 
   constructor(value: T, atomOptions: AtomOptions) {
     this.__value = value;
@@ -27,11 +28,11 @@ class Atom<T> implements IAtom<T> {
     this.options = atomOptions;
   }
 
-  get value(): T {
+  getValue() {
     return this.__value;
   }
 
-  set value(value: T) {
+  setValue(value: T) {
     this.__value = value;
     this.dispatch();
   }

--- a/src/core/hooks/useAtomSetState.ts
+++ b/src/core/hooks/useAtomSetState.ts
@@ -9,10 +9,10 @@ export const useAtomSetState = <T>(atom: IAtom<T>) => {
   const setState = useCallback<SetState<T>>(
     (setter) => {
       const nextState: T = isCallable<(state: T) => T>(setter)
-        ? setter(atom.value)
+        ? setter(atom.getValue())
         : setter;
 
-      atom.value = nextState;
+      atom.setValue(nextState);
     },
     [atom]
   );

--- a/src/core/hooks/useAtomState.ts
+++ b/src/core/hooks/useAtomState.ts
@@ -30,8 +30,8 @@ export const useAtomState: UseAtomState = <T, S>(
     [selectStateRef]
   );
 
-  const [state, setState] = useState<S>(selectState(atom.value));
-  const prevStateRef = useRef<S>(selectState(atom.value));
+  const [state, setState] = useState<S>(selectState(atom.getValue()));
+  const prevStateRef = useRef<S>(selectState(atom.getValue()));
 
   useIsomorphicLayoutEffect(() => {
     const equalFn = equalFnRef.current || atom.options.equalFn;
@@ -50,7 +50,7 @@ export const useAtomState: UseAtomState = <T, S>(
     };
 
     // Change state by changed atom value
-    const initialState = selectState(atom.value);
+    const initialState = selectState(atom.getValue());
 
     if (!equalFn(prevStateRef.current, initialState)) {
       setState(initialState);

--- a/src/core/hooks/useMergeAtom.ts
+++ b/src/core/hooks/useMergeAtom.ts
@@ -9,7 +9,7 @@ export const useMergeAtom: UseMergeAtom = (atom, merge) => {
   const setState = useAtomSetState(atom);
 
   useEffect(() => {
-    const nextState = merge(atom.value);
+    const nextState = merge(atom.getValue());
     if (nextState === undefined) {
       return;
     }


### PR DESCRIPTION
## Change atom interface
- Add `getValue` and `setValue` to `IAtom`
- Remove `value` from `IAtom`

## Why
Up to now, replacing the value property indicated the side effect of re-rendering the mounted component. However, we believe that this interface is not explicit that it has a side effect, and it was difficult to understand.

Therefore, we used a function to replace the value property to make it easier to understand that it has a side effect.