### PR TITLE
Change to return unsubscribe function when call subscribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,14 +142,13 @@ By using `atom.subscribe`, we can have a side effect when the value of atom is c
 ```ts
 const counterAtom = createAtom(0);
 
-counterAtom.subscribe((counter: number) => {
+const unsubscribe = counterAtom.subscribe((counter: number) => {
   console.log(`count is ${counter} now`)
 })
 
 // counterAtom will output 'count is 100 now' log
 counterAtom.setValue(100)
 ```
-
 
 ### Selector
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ export const Counter = () => {
 ```
 
 ### Updating state outside of react
-We can update the state by rewriting the `atom.value` directly.
+We can update the state by using `atom.setValue`.
 
 This is useful when writing operations outside of the react lifecycle.
 
@@ -148,6 +148,12 @@ const unsubscribe = counterAtom.subscribe((counter: number) => {
 
 // counterAtom will output 'count is 100 now' log
 counterAtom.setValue(100)
+
+// Unsubscribe the logging function
+unsubscribe()
+
+// counterAtom will not output log
+counterAtom.setValue(50)
 ```
 
 ### Selector

--- a/src/core/atom/atom.test.ts
+++ b/src/core/atom/atom.test.ts
@@ -31,12 +31,37 @@ describe('atom', () => {
 
     expect(countAtom.getValue()).toBe(newNumber2);
     expect(mockFn).toBeCalledTimes(2);
+  });
 
-    countAtom.unsubscribe(mockFn);
+  test('UnSubscribe atom', () => {
+    const countAtom = createAtom(0);
+    const unsubscribeMockFn = jest.fn();
+    const returnSubscribeMockFn = jest.fn();
+
+    const unsubscribe = countAtom.subscribe(returnSubscribeMockFn);
+    countAtom.subscribe(unsubscribeMockFn);
+
+    const newNumber1 = 100;
+    countAtom.setValue(newNumber1);
+
+    expect(countAtom.getValue()).toBe(newNumber1);
+    expect(unsubscribeMockFn).toBeCalledTimes(1);
+    expect(returnSubscribeMockFn).toBeCalledTimes(1);
+
+    const newNumber2 = 1000;
+    unsubscribe();
+    countAtom.setValue(newNumber2);
+
+    expect(countAtom.getValue()).toBe(newNumber2);
+    expect(unsubscribeMockFn).toBeCalledTimes(2);
+    expect(returnSubscribeMockFn).toBeCalledTimes(1);
+
     const newNumber3 = 10000;
+    countAtom.unsubscribe(unsubscribeMockFn);
     countAtom.setValue(newNumber3);
 
     expect(countAtom.getValue()).toBe(newNumber3);
-    expect(mockFn).toBeCalledTimes(2);
+    expect(unsubscribeMockFn).toBeCalledTimes(2);
+    expect(returnSubscribeMockFn).toBeCalledTimes(1);
   });
 });

--- a/src/core/atom/atom.ts
+++ b/src/core/atom/atom.ts
@@ -1,11 +1,12 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EqualFn = (a: any, b: any) => boolean;
 export type Listener<T> = (value: T) => void;
+export type Unsubscribe = () => void;
 export interface IAtom<T> {
   getValue: () => T;
   setValue: (value: T) => void;
   options: AtomOptions;
-  subscribe: (listener: Listener<T>) => void;
+  subscribe: (listener: Listener<T>) => Unsubscribe;
   unsubscribe: (listener: Listener<T>) => void;
 }
 export type AtomValue<T> = T extends Atom<infer U> ? U : never;
@@ -37,8 +38,14 @@ class Atom<T> implements IAtom<T> {
     this.dispatch();
   }
 
-  subscribe(listener: Listener<T>) {
+  subscribe(listener: Listener<T>): Unsubscribe {
     this.__listeners.push(listener);
+
+    const unsubscribe = () => {
+      this.unsubscribe(listener);
+    };
+
+    return unsubscribe;
   }
 
   unsubscribe(listener: Listener<T>) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,6 +12,7 @@ export type {
   AtomValue,
   AtomOptions,
   CreateAtom,
+  Unsubscribe,
 } from './atom/atom';
 export type { UseAtom, UseAtomOptions } from './hooks/useAtom';
 export type { UseAtomState, UseAtomStateOptions } from './hooks/useAtomState';


### PR DESCRIPTION
## Overview
- Change to return unsubscribe function when call subscribe

e.g.

```ts
const counterAtom = createAtom(0);

const unsubscribe = counterAtom.subscribe((counter: number) => {
  console.log(`count is ${counter} now`)
})

// counterAtom will output 'count is 100 now' log
counterAtom.setValue(100)

// Unsubscribe the logging function
unsubscribe()

// counterAtom will not output log
counterAtom.setValue(50)
```